### PR TITLE
Fix so that altmods and trialmods have colors (#1153)

### DIFF
--- a/src/frontend-scripts/constants.js
+++ b/src/frontend-scripts/constants.js
@@ -34,7 +34,7 @@ module.exports.LEGALCHARACTERS = text => {
  * @return {string} list of classes for colors.
  */
 module.exports.PLAYERCOLORS = (user, isSeasonal, defaultClass, eloDisabled) => {
-	if (Boolean(user.staffRole && user.staffRole.length) && !user.staffDisableStaffColor) {
+	if (Boolean(user.staffRole && user.staffRole.length && user.staffRole !== 'trialmod' && user.staffRole !== 'altmod') && !user.staffDisableStaffColor) {
 		return cn(defaultClass, {
 			admin: user.staffRole === 'admin',
 			moderatorcolor: user.staffRole === 'moderator',


### PR DESCRIPTION
Currently in playerlist and chats these staffRoles (trialmod & altmod) do not stay earned elo colors and as a result default to grey color when assigned so anonymity of these roles is not retained. This patch will fix this error in the code that I forgot when switching these roles from hardcoded values into the database for assignment convenience.