### PR TITLE
ok here's fixed version (#1386)

### DIFF
--- a/src/frontend-scripts/node-constants.js
+++ b/src/frontend-scripts/node-constants.js
@@ -116,10 +116,18 @@ module.exports.getBadWord = text => {
 		'Nazi Terms': ['1488', '卍', 'swastika']
 	};
 	// This list for all exceptions to bypass swear filter
-	const exceptions = ['if a g', 'among', 'mongolia', 'if 4 g'];
+	const exceptions = ['if a g', 'among', 'mongolia', 'if 4 g','of a g','of 4 g'];
 	let foundWord = [null, null]; // Future found bad word, in format of: [blacklisted word, variation]
+	let flatText = ""; //the future spaceless text.
+	let spacesIndex = []; //the indexes of where the spaces would be in the spaceless text. for context in exceptions.
+	for (var i = 0; i < text.length; i++) {
+		if (" " === text[i]) {
+			spacesIndex.push(flatText.length - 1); //add space to list
+		} else {
+			flatText += text[i]; //add char to text otherwise
+		}
+	}
 	// This version will detect words with spaces in them, but may have false positives (such as "mongolia" for "mong").
-	let flatText = text.replace(/ /g, '');
 	Object.keys(badWords).forEach(key => {
 		if (flatText.includes(key)) {
 			foundWord = [key, key];
@@ -132,12 +140,24 @@ module.exports.getBadWord = text => {
 			});
 		}
 		// This should detect exceptions in the filter and rule out false positives based on the list of exceptions.
-		for (let i = 0; i < exceptions.length; i++) {
+		//this version only detects for exceptions where the bad word was found.
+		let wIndex = flatText.indexOf(foundWord[1]); //the location of the blacklisted word found in flatText.
+		for (let i = 0; i < exceptions.length; i++) { //passes through all exceptions
+
+			if (text.toLowerCase().substr( //spacing weird to add notations and clarify what this long if statement does.
+				wIndex + Math.max(0, spacesIndex.filter(index => index <= wIndex).length - 1), //substrings text to find the index where the bad word would be found by determining the number of missing spaces -1 (for 'among')
+				exceptions[i].length + 1) //sets the length of the substring to be 1 longer than the exception string length to counteract the -1 for 'among'.
+				.indexOf(exceptions[i]) > -1) { //if the exception is found within the substring,
+				foundWord = [null, null]; //prevent the bad word from being detected.
+			}
+		}
+		//this version detects exceptions in the entire sentence.
+		/*for (let i = 0; i < exceptions.length; i++) {
 			if (text.indexOf(exceptions[i]) > -1) {
 				// If the exception is found within the substring,
 				foundWord = [null, null]; // Prevent the bad word from being detected.
 			}
-		}
+		}*/
 	});
 
 	// This version only detects words if they are whole and have whitespace at either end.


### PR DESCRIPTION
* Undo some modifications to language detection filter

The modifications to my original code function differently than the original beyond cleaning up.

I have reintroduced the code which checks per example rather than for the whole sentence, which fixes the following test:
https://cdn.discordapp.com/attachments/326820032116162561/567215974785482773/68e1a2154ef9cd2df06fa4dc73a2230a.png

full test case results:
https://cdn.discordapp.com/attachments/326820032116162561/567367059923533835/1bc333409999c2d2ecf15257fcffc5e6.png

* keep up with constants.js

blah blah